### PR TITLE
feat: add mnemonic exception classes for better error handling

### DIFF
--- a/lib/bip39_mnemonic.dart
+++ b/lib/bip39_mnemonic.dart
@@ -1,4 +1,5 @@
 library bip39_mnemonic;
 
 export 'src/mnemonic.dart';
+export 'src/exceptions.dart';
 export 'src/language.dart';

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,40 @@
+abstract class MnemonicException implements Exception {
+  final String message;
+
+  MnemonicException(this.message);
+
+  @override
+  String toString() => 'MnemonicException: $message';
+}
+
+class MnemonicIndexesLengthException extends MnemonicException {
+  MnemonicIndexesLengthException(int length)
+      : super("MnemonicException: indexes length $length is not valid");
+}
+
+class MnemonicUnexpectedInitialEntropyLengthException
+    extends MnemonicException {
+  MnemonicUnexpectedInitialEntropyLengthException(int length)
+      : super("MnemonicException: unexpected initial entropy length $length");
+}
+
+class MnemonicUnexpectedEntropyLengthException extends MnemonicException {
+  MnemonicUnexpectedEntropyLengthException(int length)
+      : super(
+      "MnemonicException: unexpected entropy length, choose one of: [128, 160, 192, 224, 256] but got $length");
+}
+
+class MnemonicWordNotFoundException extends MnemonicException {
+  MnemonicWordNotFoundException(String word, String language)
+      : super('mnemonic: "$word" does not exist in $language');
+}
+
+class MnemonicUnexpectedSentenceLengthException extends MnemonicException {
+  MnemonicUnexpectedSentenceLengthException(int length)
+      : super("mnemonic: unexpected sentence length: $length");
+}
+
+class MnemonicInvalidChecksumException extends MnemonicException {
+  MnemonicInvalidChecksumException(String sentence)
+      : super('mnemonic: invalid checksum for sentence: "$sentence"');
+}

--- a/lib/src/mnemonic.dart
+++ b/lib/src/mnemonic.dart
@@ -7,6 +7,7 @@ import 'package:unorm_dart/unorm_dart.dart';
 import 'crypto.dart';
 import 'language.dart';
 import 'utils.dart';
+import 'exceptions.dart';
 
 /// BIP39: A mnemonic sentence is superior for human interaction compared to the handling of raw binary or hexadecimal representations of a wallet seed.
 class Mnemonic {
@@ -54,7 +55,7 @@ class Mnemonic {
       String bit = _binary.substring(i, i + 11);
       indexes.add(int.parse(bit, radix: 2));
     }
-    indexes.length != _MS ? throw Exception("mnemonic: indexes length") : null;
+    indexes.length != _MS ? throw MnemonicIndexesLengthException(indexes.length) : null;
     return indexes;
   }
 
@@ -84,7 +85,7 @@ class Mnemonic {
   /// Constructs Mnemonic from entropy bytes.
   Mnemonic(this.entropy, this.language, {this.passphrase = ""}) {
     if (![128, 160, 192, 224, 256].contains(_ENT)) {
-      throw Exception("mnemonic: unexpected initial entropy length");
+      throw MnemonicUnexpectedInitialEntropyLengthException(_ENT);
     }
   }
 
@@ -95,8 +96,7 @@ class Mnemonic {
     int entropyLength = 256,
   }) {
     if (![128, 160, 192, 224, 256].contains(entropyLength)) {
-      throw Exception(
-          "mnemonic: unexpected entropy length, choose one of: [128, 160, 192, 224, 256]");
+      throw MnemonicUnexpectedEntropyLengthException(entropyLength);
     }
     var random = Random.secure();
     entropy = List<int>.generate(
@@ -115,7 +115,7 @@ class Mnemonic {
     for (var word in words) {
       var nfkdWord = nfkd(word);
       if (map.containsValue(nfkdWord) == false) {
-        throw Exception('mnemonic: "$word" does not exist in $language');
+        throw MnemonicWordNotFoundException(word, language.name);
       } else {
         int index =
             map.entries.firstWhere((entry) => entry.value == nfkdWord).key;
@@ -141,7 +141,7 @@ class Mnemonic {
         checksumLength = 8;
         break;
       default:
-        throw Exception("mnemonic: unexpected sentence length");
+        throw MnemonicUnexpectedSentenceLengthException(indexes.length);
     }
     // convert indexes to bits to remove the checksum.
     String bits = indexes
@@ -159,7 +159,7 @@ class Mnemonic {
       entropy.add(int.parse(bit, radix: 2));
     }
     if (_checksum != extractedChecksum) {
-      throw Exception('mnemonic: invalid checksum');
+      throw MnemonicInvalidChecksumException(sentence);
     }
   }
 

--- a/test/mnemonic_test.dart
+++ b/test/mnemonic_test.dart
@@ -38,7 +38,7 @@ void main() {
   group('Mnemonic constructors', () {
     test('Mnemonic default constructor', () {
       expect(() => Mnemonic([0], Language.french),
-          throwsA(isA<MnemonicIndexesLengthException>()));
+          throwsA(isA<MnemonicUnexpectedInitialEntropyLengthException>()));
     });
 
     test('Mnemonic.generate', () {

--- a/test/mnemonic_test.dart
+++ b/test/mnemonic_test.dart
@@ -6,30 +6,30 @@ Map<String, List<Map<String, String>>> vectors = {
     {
       "entropy": "00000000000000000000000000000000",
       "mnemonic":
-          "abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace agrese",
+      "abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace abdikace agrese",
       "passphrase": "TREZOR",
       "seed":
-          "872501bed75c98fbf943a67907bf394995f337e9adfa23687282d1135c262421715a0bcccfe2d3f5f8b72c8e2fa12a7a7267f8047b744557f4a9d49d11ccc75f"
+      "872501bed75c98fbf943a67907bf394995f337e9adfa23687282d1135c262421715a0bcccfe2d3f5f8b72c8e2fa12a7a7267f8047b744557f4a9d49d11ccc75f"
     },
   ],
   "korean": [
     {
       "entropy": "00000000000000000000000000000000",
       "mnemonic":
-          "가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가능",
+      "가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가능",
       "passphrase": "TREZOR",
       "seed":
-          "a253d07f616223e337b6fa257632a2cc37e1ba36ff0bc7cf5a943366fa1b9ef02d6aa0333da51c17902951634b8aa81b6692a194b07f4f8c542335d73c96aad3"
+      "a253d07f616223e337b6fa257632a2cc37e1ba36ff0bc7cf5a943366fa1b9ef02d6aa0333da51c17902951634b8aa81b6692a194b07f4f8c542335d73c96aad3"
     },
   ],
   "portuguese": [
     {
       "entropy": "00000000000000000000000000000000",
       "mnemonic":
-          "abacate abacate abacate abacate abacate abacate abacate abacate abacate abacate abacate abater",
+      "abacate abacate abacate abacate abacate abacate abacate abacate abacate abacate abacate abater",
       "passphrase": "TREZOR",
       "seed":
-          "ab9742b024a1e8bd241b76f8b3a157e9d442da60277bc8f36b8b23afe163de79414fb49fd1a8dd26f4ea7f0dc965c760b3b80727557bdca61e1f0b0f069952f2"
+      "ab9742b024a1e8bd241b76f8b3a157e9d442da60277bc8f36b8b23afe163de79414fb49fd1a8dd26f4ea7f0dc965c760b3b80727557bdca61e1f0b0f069952f2"
     },
   ]
 };
@@ -37,7 +37,8 @@ Map<String, List<Map<String, String>>> vectors = {
 void main() {
   group('Mnemonic constructors', () {
     test('Mnemonic default constructor', () {
-      expect(() => Mnemonic([0], Language.french), throwsException);
+      expect(() => Mnemonic([0], Language.french),
+          throwsA(isA<MnemonicIndexesLengthException>()));
     });
 
     test('Mnemonic.generate', () {
@@ -50,8 +51,8 @@ void main() {
 
     test('Mnemonic.generate from invalid entropy length', () {
       expect(
-        () => Mnemonic.generate(Language.french, entropyLength: 64),
-        throwsException,
+            () => Mnemonic.generate(Language.french, entropyLength: 64),
+        throwsA(isA<MnemonicUnexpectedEntropyLengthException>()),
       );
     });
 
@@ -59,8 +60,8 @@ void main() {
       String sentence =
           "esperanto 가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가능";
       expect(
-        () => Mnemonic.fromSentence(sentence, Language.korean),
-        throwsException,
+            () => Mnemonic.fromSentence(sentence, Language.korean),
+        throwsA(isA<MnemonicWordNotFoundException>()),
       );
     });
 
@@ -68,8 +69,8 @@ void main() {
       String sentence =
           "가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가격 가능";
       expect(
-        () => Mnemonic.fromSentence(sentence, Language.korean),
-        throwsException,
+            () => Mnemonic.fromSentence(sentence, Language.korean),
+        throwsA(isA<MnemonicUnexpectedSentenceLengthException>()),
       );
     });
 
@@ -77,18 +78,19 @@ void main() {
       String sentence =
           "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon";
       expect(
-        () => Mnemonic.fromSentence(sentence, Language.english),
-        throwsException,
+            () => Mnemonic.fromSentence(sentence, Language.english),
+        throwsA(isA<MnemonicInvalidChecksumException>()),
       );
     });
 
     test(
         'Mnemonic.fromSentence with non NFKD words will format them anyway, fougère',
-        () {
-      String sentence =
-          "insecte pirogue tamiser goudron torpille rejouer essieu lactose bouquin humble service dauphin gendarme fougère visqueux essence projeter thème éruption chausson incliner plastron bambin boiser";
-      var mnemonic = Mnemonic.fromSentence(sentence, Language.french);
-      expect(mnemonic.words[13] == 'fougère', false);
-    });
+            () {
+          String sentence =
+              "insecte pirogue tamiser goudron torpille rejouer essieu lactose bouquin humble service dauphin gendarme fougère visqueux essence projeter thème éruption chausson incliner plastron bambin boiser";
+          var mnemonic = Mnemonic.fromSentence(sentence, Language.french);
+          expect(mnemonic.words[13] == 'fougère', false);
+        });
   });
 }
+


### PR DESCRIPTION

This pull request introduces a new hierarchy of custom exceptions for the `Mnemonic` class to replace generic `Exception` usage, improving error specificity and readability. It also updates the relevant test cases to validate these new exceptions.

### Custom Exception Implementation:
* Added a new abstract base class `MnemonicException` and several specific exception classes (e.g., `MnemonicIndexesLengthException`, `MnemonicUnexpectedEntropyLengthException`) in `lib/src/exceptions.dart` to provide more meaningful error messages.
* Updated the `Mnemonic` class in `lib/src/mnemonic.dart` to throw these custom exceptions instead of generic `Exception`. [[1]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L57-R58) [[2]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L87-R88) [[3]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L98-R99) [[4]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L118-R118) [[5]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L144-R144) [[6]](diffhunk://#diff-73c4e9f5881a44dd629c05dd142a1098ef41a75959d220cec8a98a745ab759f6L162-R162)

### Test Case Updates:
* Modified test cases in `test/mnemonic_test.dart` to expect specific custom exceptions using `throwsA(isA<...>())`. This ensures the tests are aligned with the new exception hierarchy. [[1]](diffhunk://#diff-54e7591140d3d510b7028801b82d185109522881cb72ff3cf5d6189fa3279839L40-R41) [[2]](diffhunk://#diff-54e7591140d3d510b7028801b82d185109522881cb72ff3cf5d6189fa3279839L54-R55) [[3]](diffhunk://#diff-54e7591140d3d510b7028801b82d185109522881cb72ff3cf5d6189fa3279839L63-R64) [[4]](diffhunk://#diff-54e7591140d3d510b7028801b82d185109522881cb72ff3cf5d6189fa3279839L72-R73) [[5]](diffhunk://#diff-54e7591140d3d510b7028801b82d185109522881cb72ff3cf5d6189fa3279839L81-R82)